### PR TITLE
Do not load Fathom Analytics when running jekyll serve

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,7 +26,10 @@
   <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ site.baseurl }}/atom.xml">
   <link rel="alternate" type="application/json" title="{{ site.title }}" href="{{ "/feed.json" | prepend: site.baseurl | prepend: site.url }}" />
   <link rel="sitemap" type="application/xml" title="sitemap" href="{{ site.baseurl }}/sitemap.xml" />
+  
+  {% if jekyll.environment == "production" %}
   <script src="https://cdn.usefathom.com/script.js" data-site="DWTNQAIW" defer></script>
+  {% endif %}
       
   <style>
     {% capture include_to_scssify %}


### PR DESCRIPTION
Fixes #5

Add conditional check to prevent loading Fathom Analytics when running `jekyll serve`.

* Add a conditional check in `_includes/head.html` to load Fathom Analytics script only in the production environment
* Use `jekyll.environment` to determine the current environment

